### PR TITLE
Fix order of elements for internal document

### DIFF
--- a/src/Pohoda/IntDoc.php
+++ b/src/Pohoda/IntDoc.php
@@ -41,7 +41,7 @@ class IntDoc extends AbstractDocument
      */
     protected function getDocumentElements(): array
     {
-        return \array_merge(parent::getDocumentElements(), ['taxDocument']);
+        return \array_merge(['taxDocument'], parent::getDocumentElements());
     }
 
     /**

--- a/tests/AgendaTests/IntDocTest.php
+++ b/tests/AgendaTests/IntDocTest.php
@@ -63,7 +63,7 @@ class IntDocTest extends CommonTestClass
             ]
         ]);
 
-        $this->assertEquals('<int:intDoc version="2.0"><int:intDocHeader>' . $this->defaultHeader() . '</int:intDocHeader><int:taxDocument><int:sourceLiquidation><typ:sourceItemId>123456879</typ:sourceItemId></int:sourceLiquidation></int:taxDocument></int:intDoc>', $lib->getXML()->asXML());
+        $this->assertEquals('<int:intDoc version="2.0"><int:taxDocument><int:sourceLiquidation><typ:sourceItemId>123456879</typ:sourceItemId></int:sourceLiquidation></int:taxDocument><int:intDocHeader>' . $this->defaultHeader() . '</int:intDocHeader></int:intDoc>', $lib->getXML()->asXML());
     }
 
     public function testSetParams(): void


### PR DESCRIPTION
I had to reorder the XML document’s elements to place the taxDocument first, because Pohoda returned an error stating that the XML document envelope could not be validated against the schema.